### PR TITLE
feat: improve typink provider

### DIFF
--- a/examples/demo-inkv6/src/main.tsx
+++ b/examples/demo-inkv6/src/main.tsx
@@ -7,7 +7,6 @@ import { theme } from '@/theme';
 import { deployments } from '@/contracts/deployments';
 import { development, polkadotjs, popTestnet, subwallet, talisman, TypinkProvider, westendAssetHub } from 'typink';
 
-const DEFAULT_CALLER = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'; // Alice
 const SUPPORTED_NETWORK = [popTestnet, westendAssetHub];
 if (process.env.NODE_ENV === 'development') {
   SUPPORTED_NETWORK.push(development);
@@ -17,9 +16,7 @@ function Root() {
   return (
     <ChakraProvider theme={theme}>
       <TypinkProvider
-        appName='Demo Typink App'
         deployments={deployments}
-        defaultCaller={DEFAULT_CALLER}
         supportedNetworks={SUPPORTED_NETWORK}
         defaultNetworkId={popTestnet.id}
         cacheMetadata={true}

--- a/packages/typink/src/providers/TypinkProvider.tsx
+++ b/packages/typink/src/providers/TypinkProvider.tsx
@@ -2,6 +2,9 @@ import { createContext } from 'react';
 import { ClientContextProps, ClientProvider, ClientProviderProps, useClient } from './ClientProvider.js';
 import { useWallet, WalletContextProps } from './WalletProvider.js';
 import { ContractDeployment, SubstrateAddress } from '../types.js';
+
+const ALICE = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+
 import {
   useWalletSetup,
   WalletSetupContextProps,
@@ -23,12 +26,12 @@ export const TypinkContext = createContext<TypinkContextProps>({} as any);
 
 export interface TypinkProviderProps extends ClientProviderProps, WalletSetupProviderProps {
   deployments?: ContractDeployment[];
-  defaultCaller: SubstrateAddress;
+  defaultCaller?: SubstrateAddress;
 }
 
-export type TypinkProviderInnerProps = Omit<TypinkProviderProps, 'appName'>
+export type TypinkProviderInnerProps = Omit<TypinkProviderProps, 'appName'>;
 
-function TypinkProviderInner({ children, deployments = [], defaultCaller }: TypinkProviderInnerProps) {
+function TypinkProviderInner({ children, deployments = [], defaultCaller = ALICE }: TypinkProviderInnerProps) {
   const clientContext = useClient();
   const walletSetupContext = useWalletSetup();
   const walletContext = useWallet();
@@ -56,7 +59,7 @@ function TypinkProviderInner({ children, deployments = [], defaultCaller }: Typi
  * @param props - The properties for the TypinkProvider component
  * @param props.children - The child components to be rendered within the provider
  * @param props.deployments - An array of contract deployments (optional, defaults to empty array)
- * @param props.defaultCaller - The default substrate address to be used as the caller
+ * @param props.defaultCaller - The default substrate address to be used as the caller (optional, defaults to ALICE address)
  * @param props.defaultNetworkId - The default network ID to be used
  * @param props.cacheMetadata - Whether to cache metadata or not (default: false)
  * @param props.supportedNetworks - An array of supported networks
@@ -74,7 +77,7 @@ function TypinkProviderInner({ children, deployments = [], defaultCaller }: Typi
 export function TypinkProvider({
   children,
   deployments = [],
-  defaultCaller,
+  defaultCaller = ALICE,
   defaultNetworkId,
   cacheMetadata = false,
   supportedNetworks,

--- a/packages/typink/src/providers/TypinkProvider.tsx
+++ b/packages/typink/src/providers/TypinkProvider.tsx
@@ -22,13 +22,13 @@ export interface TypinkContextProps
 export const TypinkContext = createContext<TypinkContextProps>({} as any);
 
 export interface TypinkProviderProps extends ClientProviderProps, WalletSetupProviderProps {
-  deployments: ContractDeployment[];
+  deployments?: ContractDeployment[];
   defaultCaller: SubstrateAddress;
 }
 
 export type TypinkProviderInnerProps = Omit<TypinkProviderProps, 'appName'>
 
-function TypinkProviderInner({ children, deployments, defaultCaller }: TypinkProviderInnerProps) {
+function TypinkProviderInner({ children, deployments = [], defaultCaller }: TypinkProviderInnerProps) {
   const clientContext = useClient();
   const walletSetupContext = useWalletSetup();
   const walletContext = useWallet();
@@ -55,7 +55,7 @@ function TypinkProviderInner({ children, deployments, defaultCaller }: TypinkPro
  *
  * @param props - The properties for the TypinkProvider component
  * @param props.children - The child components to be rendered within the provider
- * @param props.deployments - An array of contract deployments
+ * @param props.deployments - An array of contract deployments (optional, defaults to empty array)
  * @param props.defaultCaller - The default substrate address to be used as the caller
  * @param props.defaultNetworkId - The default network ID to be used
  * @param props.cacheMetadata - Whether to cache metadata or not (default: false)
@@ -73,7 +73,7 @@ function TypinkProviderInner({ children, deployments, defaultCaller }: TypinkPro
  */
 export function TypinkProvider({
   children,
-  deployments,
+  deployments = [],
   defaultCaller,
   defaultNetworkId,
   cacheMetadata = false,

--- a/packages/typink/src/providers/TypinkProvider.tsx
+++ b/packages/typink/src/providers/TypinkProvider.tsx
@@ -3,7 +3,7 @@ import { ClientContextProps, ClientProvider, ClientProviderProps, useClient } fr
 import { useWallet, WalletContextProps } from './WalletProvider.js';
 import { ContractDeployment, SubstrateAddress } from '../types.js';
 
-const ALICE = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+const DEFAULT_ADDRESS = '5FTZ6n1wY3GBqEZ2DWEdspbTarvRnp8DM8x2YXbWubu7JN98';
 
 import {
   useWalletSetup,
@@ -19,7 +19,7 @@ export interface TypinkContextProps
     WalletContextProps,
     TypinkEventsContextProps {
   deployments: ContractDeployment[];
-  defaultCaller: SubstrateAddress; // TODO validate substrate address
+  defaultCaller: SubstrateAddress;
 }
 
 export const TypinkContext = createContext<TypinkContextProps>({} as any);
@@ -31,7 +31,11 @@ export interface TypinkProviderProps extends ClientProviderProps, WalletSetupPro
 
 export type TypinkProviderInnerProps = Omit<TypinkProviderProps, 'appName'>;
 
-function TypinkProviderInner({ children, deployments = [], defaultCaller = ALICE }: TypinkProviderInnerProps) {
+function TypinkProviderInner({
+  children,
+  deployments = [],
+  defaultCaller = DEFAULT_ADDRESS,
+}: TypinkProviderInnerProps) {
   const clientContext = useClient();
   const walletSetupContext = useWalletSetup();
   const walletContext = useWallet();
@@ -77,7 +81,7 @@ function TypinkProviderInner({ children, deployments = [], defaultCaller = ALICE
 export function TypinkProvider({
   children,
   deployments = [],
-  defaultCaller = ALICE,
+  defaultCaller = DEFAULT_ADDRESS,
   defaultNetworkId,
   cacheMetadata = false,
   supportedNetworks,

--- a/packages/typink/src/providers/WalletSetupProvider.tsx
+++ b/packages/typink/src/providers/WalletSetupProvider.tsx
@@ -36,7 +36,7 @@ export const useWalletSetup = () => {
 };
 
 export interface WalletSetupProviderProps extends WalletProviderProps {
-  appName: string;
+  appName?: string;
   wallets?: Wallet[];
 }
 
@@ -50,13 +50,14 @@ const DEFAULT_WALLETS: Wallet[] = [subwallet, talisman, polkadotjs];
  * @param props.children - The child components to be wrapped by this provider.
  * @param props.signer - The initial signer object for the wallet.
  * @param props.connectedAccount - The initial connected account information.
+ * @param props.appName - The application name to use when enabling wallets (optional, defaults to empty string).
  */
 export function WalletSetupProvider({
   children,
   signer: initialSigner,
   connectedAccount: initialConnectedAccount,
   wallets: initialWallets,
-  appName
+  appName = ''
 }: WalletSetupProviderProps) {
   const wallets = useMemo(() => initialWallets || DEFAULT_WALLETS, useDeepDeps([initialWallets]));
   const [accounts, setAccounts] = useState<InjectedAccount[]>([]);


### PR DESCRIPTION
Make required props optional: `defaultCaller`, `deployments` & `appName`. This helps general dapps can use TypinkProvider without having to provide those props. 